### PR TITLE
Add support for additional stats in DataDog upload

### DIFF
--- a/http-canary.go
+++ b/http-canary.go
@@ -38,6 +38,8 @@ var device map[string]deviceContext
 // Canary handler
 func inboundWebCanaryHandler(httpRsp http.ResponseWriter, httpReq *http.Request) {
 
+	AddAdditionalStat("canary_called", 1)
+
 	// Exit
 	if Config.CanaryDisabled {
 		return

--- a/stats.go
+++ b/stats.go
@@ -80,6 +80,30 @@ var statsLock sync.Mutex
 var stats map[string]HostStats
 var statsServiceVersions map[string]string
 
+type AdditionalStat struct {
+	Name	string
+	Values	[]StatValue
+}
+
+type StatValue struct {
+	Time	int64
+	Value	int64
+}
+
+var AdditionalStats map[string]AdditionalStat
+
+func AddAdditionalStat(name string, value int64) {
+    stat, ok := AdditionalStats[name]
+    if !ok {
+        // If the stat does not exist, create it
+        stat = AdditionalStat{Name: name}
+    }
+    // Add the new value
+    stat.Values = append(stat.Values, StatValue{Time: todayTime(), Value: value})
+    // Put the stat back into the map
+    AdditionalStats[name] = stat
+}
+
 // Trace
 const addStatsTrace = true
 
@@ -709,7 +733,9 @@ func statsUpdateHost(hostname string, hostaddr string, reload bool) (ss serviceS
 	// If this is just the initial set of stats that were being loaded from the file system, ignore it,
 	// else write the stats to datadog
 	if len(addedStats) > 0 && time.Now().UTC().Unix() > statsInitCompleted+60 {
-		datadogUploadStats(hostname, ss.BucketSecs, addedStats)
+		datadogUploadStats(hostname, ss.BucketSecs, addedStats, AdditionalStats)
+		// Clean up the additional stats so it doesn't keep growing.
+		AdditionalStats = map[string]AdditionalStat{}
 	}
 
 	// Done


### PR DESCRIPTION
This should add an additional metric to datadog. We can use this to check if the canary hasn't been called in a while to alarm on that.