### PR TITLE
Send queuing information to new slack channel

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type ServiceConfig struct {
 
 	// Slack app integration
 	SlackWebhookURL string `json:"slack_webhook_url,omitempty"`
+	SlackVerboseWebhookURL string `json:"slack_verbose_webhook_url,omitempty"`
 
 	// AWS info used for S3 upload
 	AWSRegion      string `json:"aws_region,omitempty"`

--- a/slack.go
+++ b/slack.go
@@ -29,6 +29,17 @@ func slackSendMessage(message string) (err error) {
 
 }
 
+// Sends to the verbose Slack channel, which is used for debugging
+func slackSendVerboseMessage(message string) (err error) {
+
+	payload := &slack.WebhookMessage{
+		Text: message,
+	}
+
+	return slack.PostWebhook(Config.SlackVerboseWebhookURL, payload)
+
+}
+
 // Slack inbound 'slash command' request handler
 func inboundWebSlackRequestHandler(w http.ResponseWriter, r *http.Request) {
 

--- a/watcher.go
+++ b/watcher.go
@@ -624,7 +624,7 @@ func watcherGetStats(hostname string, hostaddr string, warnWhenPendingEventsPerH
 			eventsPending := sistats[0].EventsEnqueued - sistats[0].EventsDequeued
 			if eventsPending > int64(warnWhenPendingEventsPerHandlerExceed) {
 				message := fmt.Sprintf("%s: %s %d pending events (%d routed [%.1f/min] in the last %d mins)\n", hostname, h.NodeName, eventsPending, lastEventsCount[h.NodeName], lastEventsThroughput[h.NodeName]*60, int(lastEventsThroughputSecs[h.NodeName]/60))
-				slackSendMessage(message)
+				slackSendVerboseMessage(message)
 			}
 		}
 
@@ -784,7 +784,7 @@ func watcherActivity(hostname string, instanceOfInterest string, countOfInterest
 				message += "instance not found"
 			}
 		}
-		slackSendMessage(message)
+		slackSendVerboseMessage(message)
 	}
 	return ""
 


### PR DESCRIPTION
In an effort to keep the ops channel streamlined for on-call events, I'm introducing a new ops-verbose channel to capture a subset of notehub watch messages, like queue monitoring.

Let's try this arrangement out and we can adjust as needed.